### PR TITLE
将生成 SQL 中 String 类型值包含「'」（单引号）的地方转换为「\'」

### DIFF
--- a/src/main/java/com/github/zhuchao941/canal2sql/util/Canal2SqlUtils.java
+++ b/src/main/java/com/github/zhuchao941/canal2sql/util/Canal2SqlUtils.java
@@ -8,11 +8,15 @@ import java.util.Date;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 public class Canal2SqlUtils {
 
     private static final List<String> typesRequiringQuotes = Arrays.asList("char", "varchar", "binary", "varbinary", "blob", "text", "enum", "set", "json", "date", "datetime", "timestamp", "time", "year");
+    // 预编译正则表达式模式
+    private static final Pattern PATTERN_SINGLE_QUOTE = Pattern.compile("'");
 
     public static String binlog2Insert(CanalEntry.Entry entry, List<CanalEntry.Column> columns) {
         StringBuilder sb = new StringBuilder();
@@ -134,7 +138,10 @@ public class Canal2SqlUtils {
             mysqlType = split[0];
         }
         if (typesRequiringQuotes.contains(mysqlType)) {
-            return "'" + column.getValue() + "'";
+            // 使用预编译的模式进行替换
+            Matcher matcher = PATTERN_SINGLE_QUOTE.matcher(column.getValue());
+            String escapedStr = matcher.replaceAll("\\\\'");
+            return "'" + escapedStr + "'";
         }
         return column.getValue();
     }


### PR DESCRIPTION
将生成 SQL 中 String 类型值包含「'」（单引号）的地方转换为「'」，避免生成的 SQL 格式错误，导致无法执行。
```
# 调整前生成的语句（存在语法错误）
UPDATE user SET `name` = '李四'王五' WHERE `id` = 1; 
# 调整后生成的语句
UPDATE user SET `name` = '李四\'王五' WHERE `id` = 1; 
```